### PR TITLE
Fixes "can't modify frozen NilClass" error case where the result of f…

### DIFF
--- a/lib/active_resource_response/response_method.rb
+++ b/lib/active_resource_response/response_method.rb
@@ -60,7 +60,7 @@ module ActiveResourceResponse
 
       def wrap_result(result)
         result = SimpleDelegator.new(result) unless result.duplicable?
-        result.instance_variable_set(:@http_response, connection.http_response)
+        result.instance_variable_set(:@http_response, connection.http_response) unless result.frozen?
         result.singleton_class.send(:define_method, self.http_response_method) do
           @http_response
         end


### PR DESCRIPTION
There are some scenarios in which ActiveResouce's `find` will return nil. 

nil is frozen in Ruby 2.2 and trying to assign an instance variable to it yields a runtime error.